### PR TITLE
Configura língua para pt_BR e página padrão

### DIFF
--- a/financeiro/main.beancount
+++ b/financeiro/main.beancount
@@ -1,6 +1,9 @@
 ; Configurações
+option "title" "apyb"
 option "operating_currency" "BRL"
 2022-11-06 custom "fava-option" "show_closed_accounts" "true"
+2023-07-02 custom "fava-option" "language" "pt_BR"
+2023-07-02 custom "fava-option" "default_page" "balance_sheet/"
 
 ; APyB ========================================================================
 2020-01-02 open Assets:Bancos:BB BRL


### PR DESCRIPTION
- Muda língua do site de inglês para português
- Configura página inicial para `/balance_sheet` (balanço) das contas
- Configura título do arquivo `main.beancount`. Essa configuração é usada para definir o prefixo da URL, mudando de `https://financeiro.python.org.br/beancount` para `https://financeiro.python.org.br/apyb`