### PR TITLE
Correcao de destinacao do patrocinio da psf para pyse2024

### DIFF
--- a/financeiro/2024-07.beancount
+++ b/financeiro/2024-07.beancount
@@ -207,8 +207,8 @@
 2024-07-23 * "Patrocinio" "PSF - ORPAG ORIGEM EXTERIOR / DEP"
   comprovante: "https://drive.google.com/file/d/18TwsKSzBEY5rwZ7OBwhPyxKxWeIhwE02/view?usp=drive_link"
   Assets:Bancos:BB 19444.74 * 0.1 BRL
-  Assets:Eventos:Pyne2024  19444.74 * 0.9  BRL
-  Income:Eventos:Pyne2024
+  Assets:Eventos:Pyse2024  19444.74 * 0.9  BRL
+  Income:Eventos:Pyse2024
 
 2024-07-23 * "Patrocinio" "PSF - ORPAG ORIGEM EXTERIOR / DEP (Essa transação financeira está particionada, pois a PSF depositou o patrocínio da Python Brasil 2023 e Python Sul 2024 juntos totalizando R$ 99.983,55)"
   comprovante: "https://drive.google.com/file/d/1TyQ-GNlay3-TO19FUMrCVN5KefahgSbA/view?usp=drive_link"


### PR DESCRIPTION
Correcao de destinacao do patrocinio da psf para pyse2024. Detectada marcacao indevida do patrocinio para pyne2024, sendo que este ja havia sido recebido em maio2024.