### PR TITLE
Caixa mai/2026

### DIFF
--- a/extratos/2026-05-bb.ofx
+++ b/extratos/2026-05-bb.ofx
@@ -1,0 +1,478 @@
+
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:UTF-8
+CHARSET:NONE
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+
+<OFX>
+  <SIGNONMSGSRSV1>
+   <SONRS>
+    <STATUS>
+      <CODE>0</CODE>
+      <SEVERITY>INFO</SEVERITY>
+    </STATUS>
+    <DTSERVER>20260610122124[-3:BRT]</DTSERVER>
+    <LANGUAGE>POR</LANGUAGE>
+    <FI>
+     <ORG>Banco do Brasil</ORG>
+     <FID>1</FID>
+    </FI>
+   </SONRS>
+  </SIGNONMSGSRSV1>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <TRNUID>1</TRNUID>
+        <STATUS>
+        <CODE>0</CODE>
+        <SEVERITY>INFO</SEVERITY>
+       </STATUS>
+      <STMTRS>
+        <CURDEF>BRL</CURDEF>
+        <BANKACCTFROM>
+          <BANKID>1</BANKID>
+          <BRANCHID>89</BRANCHID>
+          <ACCTID>78126</ACCTID>
+          <ACCTTYPE>CHECKING</ACCTTYPE>
+        </BANKACCTFROM>
+        <BANKTRANLIST>
+            <DTSTART>20260531000000[-3:BRT]</DTSTART>
+            <DTEND>20260610122124[-3:BRT]</DTEND>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260429000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>102068.85</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo Anterior</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>4784.07</TRNAMT>
+              <FITID>60.013.626</FITID>
+              <NAME>ORPAG ORIGEM EXTERIOR</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>116.55</TRNAMT>
+              <FITID>100.303.121</FITID>
+              <NAME>TED-Pag Fornecedores</NAME>
+              <MEMO>745 0001 22121209000146 STRIPE BRASIL</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>5000.00</TRNAMT>
+              <FITID>32.004.337.472.901</FITID>
+              <NAME>Pix - Recebido</NAME>
+              <MEMO>03/05 20:04 08789778804 LUCIANO GAMA D</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>82.56</TRNAMT>
+              <FITID>111.240.100.000.444</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-18.18</TRNAMT>
+              <FITID>60.013.626</FITID>
+              <NAME>Cobrança de I.O.F.</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260504000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>112033.85</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260505000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>116.55</TRNAMT>
+              <FITID>100.305.863</FITID>
+              <NAME>TED-Pag Fornecedores</NAME>
+              <MEMO>745 0001 22121209000146 STRIPE BRASIL</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260505000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>112150.40</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260506000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>115.71</TRNAMT>
+              <FITID>100.308.492</FITID>
+              <NAME>TED-Pag Fornecedores</NAME>
+              <MEMO>745 0001 22121209000146 STRIPE BRASIL</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260506000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>540.52</TRNAMT>
+              <FITID>111.260.100.000.570</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260506000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>112806.63</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260507000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>115.71</TRNAMT>
+              <FITID>100.311.923</FITID>
+              <NAME>TED-Pag Fornecedores</NAME>
+              <MEMO>745 0001 22121209000146 STRIPE BRASIL</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260507000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>112922.34</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>143.62</TRNAMT>
+              <FITID>111.280.200.000.224</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-125.00</TRNAMT>
+              <FITID>50.801</FITID>
+              <NAME>Pagamento de Boleto</NAME>
+              <MEMO>VILLA URBANA STUDIO CRIATIVO L</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-285.00</TRNAMT>
+              <FITID>50.802</FITID>
+              <NAME>Pix - Enviado</NAME>
+              <MEMO>08/05 17:19 ATUALE ASSESSORIA CONTABI</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-2555.00</TRNAMT>
+              <FITID>50.803</FITID>
+              <NAME>Pix - Enviado</NAME>
+              <MEMO>08/05 17:31 44.498.887 MAIRLEY DA TRI</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-12.82</TRNAMT>
+              <FITID>851.281.200.013.663</FITID>
+              <NAME>Tarifa Pix Enviado</NAME>
+              <MEMO>Tar. agrupadas - ocorrencia 08/05/2026</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260508000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>110088.14</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260511000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>881.34</TRNAMT>
+              <FITID>111.310.300.000.105</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260511000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>110969.48</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260512000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>160.45</TRNAMT>
+              <FITID>111.320.200.000.211</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260512000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-8.82</TRNAMT>
+              <FITID>51.201</FITID>
+              <NAME>Pagamento de Impostos</NAME>
+              <MEMO>PREF MUN CAXIAS DO SUL</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260512000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-135.85</TRNAMT>
+              <FITID>51.202</FITID>
+              <NAME>Pix - Enviado</NAME>
+              <MEMO>12/05 16:06 Marcelo Miky Mine</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260512000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-1.34</TRNAMT>
+              <FITID>891.321.200.014.344</FITID>
+              <NAME>Tarifa Pix Enviado</NAME>
+              <MEMO>Tar. agrupadas - ocorrencia 12/05/2026</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260512000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>110983.92</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260513000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>236.27</TRNAMT>
+              <FITID>111.330.200.000.296</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260513000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>111220.19</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260515000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-159.20</TRNAMT>
+              <FITID>841.351.100.473.567</FITID>
+              <NAME>Tarifa Pacote de Serviços</NAME>
+              <MEMO>Cobrança referente 15/05/2026</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260515000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>111060.99</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260518000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>299.64</TRNAMT>
+              <FITID>111.380.200.000.218</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260518000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>111360.63</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260519000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>24979.85</TRNAMT>
+              <FITID>60.064.459</FITID>
+              <NAME>ORPAG ORIGEM EXTERIOR</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260519000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>60.22</TRNAMT>
+              <FITID>111.390.100.000.991</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260519000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-94.92</TRNAMT>
+              <FITID>60.064.459</FITID>
+              <NAME>Cobrança de I.O.F.</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260519000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>136305.78</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260520000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>5000.00</TRNAMT>
+              <FITID>201.502.124.576.381</FITID>
+              <NAME>Pix - Recebido</NAME>
+              <MEMO>20/05 15:02 19259743000109 VINTA SOFTW</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260520000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>141305.78</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260521000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>74.50</TRNAMT>
+              <FITID>111.410.100.000.590</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260521000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>141380.28</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260522000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>74.50</TRNAMT>
+              <FITID>111.420.100.000.556</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260522000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>141454.78</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260525000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>1645.73</TRNAMT>
+              <FITID>111.450.100.000.326</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>DEBIT</TRNTYPE>
+              <DTPOSTED>20260525000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>-890.00</TRNAMT>
+              <FITID>52.501</FITID>
+              <NAME>Pix - Enviado</NAME>
+              <MEMO>25/05 09:39 ART POINT GRAFICA SAO CAR</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260525000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>142210.51</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260526000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>798.07</TRNAMT>
+              <FITID>111.460.100.000.873</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260526000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>5000.00</TRNAMT>
+              <FITID>260.715.022.523.552</FITID>
+              <NAME>Pix - Recebido</NAME>
+              <MEMO>26/05 07:15 05506560000136 NUCLEO DE I</MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260526000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>148008.58</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260528000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>498.09</TRNAMT>
+              <FITID>111.480.100.000.657</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260528000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>148506.67</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260529000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>151.70</TRNAMT>
+              <FITID>111.490.100.000.565</FITID>
+              <NAME>Stripe Crédito</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+            <STMTTRN>
+              <TRNTYPE>CREDIT</TRNTYPE>
+              <DTPOSTED>20260529000000[-3:BRT]</DTPOSTED>
+              <TRNAMT>148658.37</TRNAMT>
+              <FITID></FITID>
+              <NAME>Saldo do dia</NAME>
+              <MEMO> </MEMO>
+            </STMTTRN>
+      </BANKTRANLIST>
+      <LEDGERBAL>
+        <BALAMT>148658.37</BALAMT>
+        <DTASOF>20260531000000[-3:BRT]</DTASOF>
+      </LEDGERBAL>
+    </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>

--- a/financeiro/2026-05.beancount
+++ b/financeiro/2026-05.beancount
@@ -30,7 +30,7 @@
 2026-05-08 * "Designer" "Pix - Enviado / 08/05 17:31 44.498.887 MAIRLEY DA TRI"
   comprovante: "https://drive.google.com/file/d/1W3RKMLLTOTpu94hWp-OvwROekrIpoQqV/view?usp=drive_link"
   Assets:Eventos:Pyn2026 -2555.00 BRL
-  Expenses:Eventos:Pybr2026
+  Expenses:Eventos:Pyn2026
 
 2026-05-08 * "Tarifa" "Tarifa Pix Enviado / Tar. agrupadas - ocorrencia 08/05/2026"
   Assets:Bancos:BB -12.82 BRL

--- a/financeiro/2026-05.beancount
+++ b/financeiro/2026-05.beancount
@@ -1,0 +1,110 @@
+;; -*- mode: beancount -*-
+;; extratos/2026-05-bb.ofx
+
+2026-05-04 * "Patrocínio" "ORPAG ORIGEM EXTERIOR"
+  comprovante: "https://drive.google.com/file/d/1kbNRW2dSNM01K6XTAsaXFviaPdk0BnJt/view?usp=drive_link"
+  Assets:Bancos:BB  4784.07 * 0.1 BRL
+  Assets:Eventos:Pybr2026 4784.07 * 0.9 BRL
+  Income:Eventos:Pybr2026
+
+2026-05-04 * "Patrocínio" "Pix - Recebido / 03/05 20:04 08789778804 LUCIANO GAMA D"
+  comprovante: "https://drive.google.com/file/d/1o6aNrYzbJBOd0NDkNOpwfGRggW_pwguh/view?usp=drive_link"
+  Assets:Bancos:BB  5000.00 * 0.1 BRL
+  Assets:Eventos:Pybr2025 5000.00 * 0.9 BRL
+  Income:Eventos:Pybr2025
+
+2026-05-04 * "Tarifa" "Cobrança de I.O.F."
+  Assets:Eventos:Pybr2026  -18.18 BRL
+  Expenses:Eventos:Pybr2026
+
+2026-05-08 * "Domicílio Fiscal" "Pagamento de Boleto / VILLA URBANA STUDIO CRIATIVO L"
+  comprovante: "https://drive.google.com/file/d/1-dyVv2bg4_tIjcrd6iLmVN9dDjJ85ZgM/view?usp=drive_link"
+  Assets:Bancos:BB  -125.00 BRL
+  Expenses:APyB:Infra
+
+2026-05-08 * "Assessoria Contábil" "Pix - Enviado / 08/05 17:19 ATUALE ASSESSORIA CONTABI"
+  comprovante: "https://drive.google.com/file/d/1OLIjbengqNKkEG3E5Z23gFDofyUrfhpi/view?usp=drive_link"
+  Assets:Bancos:BB  -285.00 BRL
+  Expenses:APyB:Contadora
+
+2026-05-08 * "Designer" "Pix - Enviado / 08/05 17:31 44.498.887 MAIRLEY DA TRI"
+  comprovante: "https://drive.google.com/file/d/1W3RKMLLTOTpu94hWp-OvwROekrIpoQqV/view?usp=drive_link"
+  Assets:Eventos:Pyn2026 -2555.00 BRL
+  Expenses:Eventos:Pybr2026
+
+2026-05-08 * "Tarifa" "Tarifa Pix Enviado / Tar. agrupadas - ocorrencia 08/05/2026"
+  Assets:Bancos:BB -12.82 BRL
+  Expenses:APyB:Taxas:BB
+
+2026-05-12 * "Impostos" "Pagamento de Impostos / PREF MUN CAXIAS DO SUL"
+  comprovante: "https://drive.google.com/file/d/1l41pl65kc_fFrObkf6CxorOCy7hZPk7g/view?usp=drive_link"
+  Assets:Bancos:BB  -8.82 BRL
+  Expenses:APyB:Impostos
+
+2026-05-12 * "Reemmbolso" "AWS - Pix - Enviado / 12/05 16:06 Marcelo Miky Mine"
+  comprovante: "https://drive.google.com/file/d/18BCbv_z2XlM8YpF1FkDJ_qGsWfucbqw1/view?usp=drive_link"
+  Assets:Bancos:BB  -135.85 BRL
+  Expenses:APyB:Ops
+
+2026-05-12 * "Tarifa" "Tarifa Pix Enviado / Tar. agrupadas - ocorrencia 12/05/2026"
+  Assets:Bancos:BB  -1.34 BRL
+  Expenses:APyB:Taxas:BB
+
+2026-05-15 * "Tarifa" "Tarifa Pacote de Serviços / Cobrança referente 15/05/2026"
+  Assets:Bancos:BB  -159.20 BRL
+  Expenses:APyB:Taxas:BB
+
+2026-05-19 * "Patrocínio" "ORPAG ORIGEM EXTERIOR"
+  comprovante: "https://drive.google.com/file/d/17A2NhBO0EztmxGUc8JYV6FxPA3MRJ6Jr/view?usp=drive_link"
+  Assets:Bancos:BB  24979.85 * 0.1 BRL
+  Assets:Eventos:Pybr2025 24979.85 * 0.9 BRL
+  Income:Eventos:Pybr2025
+
+2026-05-19 * "Cobrança de I.O.F."
+  Assets:Eventos:Pybr2025  -94.92 BRL
+  Expenses:Eventos:Pybr2025
+
+2026-05-20 * "Patrocínio" "Pix - Recebido / 20/05 15:02 19259743000109 VINTA SOFTW"
+  comprovante: "https://drive.google.com/file/d/1eZOXHolS9K1tQKJy6akLiwj1y_bXd0wh/view?usp=drive_link"
+  Assets:Bancos:BB  5000.00 * 0.1 BRL
+  Assets:Eventos:Pyne2026 5000.00 * 0.9 BRL
+  Income:Eventos:Pyne2026
+
+2026-05-25 * "Gráfica" "Pix - Enviado / 25/05 09:39 ART POINT GRAFICA SAO CAR"
+  comprovante: "https://drive.google.com/file/d/155t4jCeWbwGs-wnh5HYN1gPqbHtb5UWe/view?usp=drive_link"
+  Assets:Eventos:Caipyra2026 -890.00 BRL
+  Expenses:Eventos:Caipyra2026
+
+2026-05-26 * "Patrocínio" "Pix - Recebido / 26/05 07:15 05506560000136 NUCLEO DE I"
+  comprovante: "https://drive.google.com/file/d/1DuG6acjuTutBrtxdeuFVKueZXzRp1Qev/view?usp=drive_link"
+  Assets:Bancos:BB  5000.00 * 0.1 BRL
+  Assets:Eventos:Caipyra2026 5000.00 * 0.9 BRL
+  Income:Eventos:Caipyra2026
+
+2026-05-31 * "Anuidades" "Anuidades recebidas na Stripe em Maio"
+  comprovante: ""
+  Assets:Bancos:BB  588.32 BRL
+  Income:APyB:Anuidades
+
+2026-05-31 * "Ingressos" "Ingressos Caipyra2026 recebidos na Stripe em Maio"
+  comprovante: ""
+  Assets:Bancos:BB  979.29 * 0.1 BRL
+  Assets:Eventos:Caipyra2026  979.29 * 0.9 BRL
+  Income:Eventos:Caipyra2026
+
+2026-05-31 * "Ingressos" "Ingressos Pybr2026 recebidos na Stripe em Maio"
+  comprovante: ""
+  Assets:Bancos:BB  3009.24 * 0.1 BRL
+  Assets:Eventos:Pybr2026  3009.24 * 0.9 BRL
+  Income:Eventos:Pybr2026
+
+2026-05-31 * "Ingressos" "Ingressos Pyse2026 recebidos na Stripe em Maio"
+  comprovante: ""
+  Assets:Bancos:BB  1543.31 * 0.1 BRL
+  Assets:Eventos:Pyse2026  1543.31 * 0.9 BRL
+  Income:Eventos:Pyse2026
+
+2026-05-31 * "Tarifa" "Tarifas Stripe de Maio"
+  comprovante: ""
+  Assets:Bancos:BB  -8.43 BRL
+  Expenses:APyB:Taxas:Stripe

--- a/financeiro/main.beancount
+++ b/financeiro/main.beancount
@@ -12,6 +12,7 @@ option "operating_currency" "BRL"
 2021-03-25 open Equity:Investimentos:BB BRL
 2020-09-09 open Expenses:APyB:Contadora BRL
 2020-01-15 open Expenses:APyB:Taxas:BB BRL
+2020-01-15 open Expenses:APyB:Taxas:Stripe BRL
 2022-07-01 open Expenses:APyB:Jurídico BRL
 2020-03-13 open Expenses:APyB:Impostos BRL
 2020-11-04 open Expenses:APyB:Infra BRL
@@ -121,7 +122,11 @@ option "operating_currency" "BRL"
 2024-12-03 open Expenses:Eventos:Pyne2025 BRL
 2025-12-30 close Assets:Eventos:Pyne2025 
 2025-12-30 close Income:Eventos:Pyne2025 
-2025-12-30 close Expenses:Eventos:Pyne2025 
+2025-12-30 close Expenses:Eventos:Pyne2025
+; Python Nordeste 2026
+2026-05-01 open Assets:Eventos:Pyne2026 BRL
+2026-05-01 open Income:Eventos:Pyne2026 BRL
+2026-05-01 open Expenses:Eventos:Pyne2026 BRL
 
 ; Python Norte 2023
 2023-07-07 open Assets:Eventos:Pyn2023 BRL
@@ -183,6 +188,10 @@ option "operating_currency" "BRL"
 2025-12-30 close Assets:Eventos:Pyse2025 
 2025-12-30 close Income:Eventos:Pyse2025 
 2025-12-30 close Expenses:Eventos:Pyse2025 
+; Python Sudeste 2026
+2026-05-01 open Assets:Eventos:Pyse2026 BRL
+2026-05-01 open Income:Eventos:Pyse2026 BRL
+2026-05-01 open Expenses:Eventos:Pyse2026 BRL
 
 ; 10º Meetup Grupy-RN
 2022-10-06 open Assets:Eventos:10MeetupGrupyRN BRL
@@ -357,3 +366,4 @@ include "2026-01.beancount"
 include "2026-02.beancount"
 include "2026-03.beancount"
 include "2026-04.beancount"
+include "2026-05.beancount"


### PR DESCRIPTION
A partir desse mês, começamos a ter muitas vendas de ingressos no `pretix`, de forma que ficou inviável manter as transações da `Stripe` de forma individual como vinha sendo feito.

O motivo principal é por conta da forma com que a `Stripe` agrupa os pagamentos, podendo ter um `payout` com várias `transactions` de eventos diferentes.

Para conseguir declarar os assets corretamente, o @zsinx6 criou um script para conferir na API da `Stripe` e na API do `pretix` quais transactions são referentes a quais eventos/anuidades, e os valores agrupados estão declarados como `incomes` no `.beancount`.

Para o mês de Maio, por exemplo, o relatório gerado segue abaixo:

<img width="1626" height="1394" alt="image" src="https://github.com/user-attachments/assets/199d4857-b4ed-49db-a97e-5a8984913f2a" />
